### PR TITLE
Fix timezones

### DIFF
--- a/_data/events.yml
+++ b/_data/events.yml
@@ -7,28 +7,28 @@
 #   description: sentence or two (max 60 words)
 
 
-- name: dbt Learn (GMT-5/East Coast)
+- name: dbt Learn (UTC-4/East Coast)
   type: Education
   start: June 10
   location: Distributed
   url: https://buytickets.at/fishtownanalytics/367695
   image: https://images.unsplash.com/photo-1554752191-343d87d6c28f?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1504&q=80
   description: "dbt Learn is a two-day training program that teaches analysts the tools and knowledge needed to own the entire analytics engineering workflow."
-- name: dbt Learn (GMT-7/West Coast)
+- name: dbt Learn (UTC-7/West Coast)
   type: Education
   start: May 28
   location: Distributed
   url: https://buytickets.at/fishtownanalytics/367694
   image: https://images.unsplash.com/photo-1554752191-343d87d6c28f?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1504&q=80
   description: "dbt Learn is a two-day training program that teaches analysts the tools and knowledge needed to own the entire analytics engineering workflow."
-- name: dbt Learn (GMT/London)
+- name: dbt Learn (UTC+1/London)
   type: Education
   start: May 13
   location: Distributed
   url: https://buytickets.at/fishtownanalytics/367693
   image: https://images.unsplash.com/photo-1554752191-343d87d6c28f?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1504&q=80
   description: "dbt Learn is a two-day training program that teaches analysts the tools and knowledge needed to own the entire analytics engineering workflow."
-- name: dbt Learn (GMT-5/East Coast)
+- name: dbt Learn (UTC-4/East Coast)
   type: Education
   start: April 29
   location: Distributed


### PR DESCRIPTION
I've:
- replaced `GMT` with `UTC`. They mean the same thing, but UTC is more widely used in data communities
- fixed the numbers to reflect daylight savings

I'd prefer not to revert the first, because I think it just makes sense that we're talking to data people so we use the right word, but I can if we have to. 

The second is a genuine correction though