### PR TITLE
Add HTTP headers for redirect security

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -7,7 +7,8 @@ owner: http://github.com/fishtown-analytics
 repo: https://github.com/fishtown-analytics/events.getdbt.com
 robots: true
 
-include: [_redirects]
+# these files are used by Netlify; Jekyll does nothing with them, but they need to be included in _site
+include: [_redirects, _headers]
 
 nav_links:
   home: https://www.getdbt.com

--- a/_headers
+++ b/_headers
@@ -1,0 +1,5 @@
+/*
+  Content-Security-Policy: object-src 'none'; frame-ancestors 'none'
+  X-Frame-Options: DENY
+  X-XSS-Protection: 1; mode=block
+  Strict-Transport-Security: max-age=63072000


### PR DESCRIPTION
Per this [Asana task](https://app.asana.com/0/1200099998847559/1202727990594956/f), we are adding a basic set of HTTP headers to this site (which only serves redirects).

Note: since all pages on this site redirect to www, the preview link below won't be helpful; we can really only look at the HTTP headers in the code.

Resolves [SECENG-89](https://dbtlabs.atlassian.net/browse/SECENG-89)